### PR TITLE
Netlify to modal

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -184,3 +184,17 @@ $(document).ready(function () {
   }
 
 });
+
+function passName() {
+    var input = document.getElementById("subscribe").value;
+    localStorage.setItem("user", input);
+}
+
+$(document).ready(function () {
+    if (window.location.pathname == "/thanks") {
+        console.log("ran");
+        var username = localStorage.getItem("user");
+        $("h2").text("Thank you for subscribing " + username);
+    }
+
+});

--- a/index.html
+++ b/index.html
@@ -645,12 +645,12 @@ page_id: home
             <div class="lgx-subscriber-area">
               <h4 class="title">Don’t miss any updates of our new templates and extensions and all the astonishing offers we bring for you.</h4>
               <div class="lgx-subscriber">
-                <form name="Blog Signup" method="POST" class="subscribe-form">
+                <form name="Blog Signup" method="POST" data-netlify="true" class="subscribe-form">
                   <div class="form-group">
                     <input name="email" type="email" id="subscribe" placeholder="Ex: yourname@gmail.com" class="form-control lgx-input-form form-control" />
                   </div>
                   <div class="form-group">
-                    <button type="button" data-toggle="modal" data-target="#thank-you-modal" name="lgx-submit" id="lgx-submit" class="lgx-submit the-submit-btn rippler rippler-default"><i class="fa fa-long-arrow-right" aria-hidden="true"></i></button>
+                    <button type="submit" data-toggle="modal" data-target="#thank-you-modal" name="lgx-submit" id="lgx-submit" class="lgx-submit the-submit-btn rippler rippler-default"><i class="fa fa-long-arrow-right" aria-hidden="true"></i></button>
                     <div id="thank-you-modal" class="modal fade lgx-modal">
                       <div class="modal-dialog">
                         <div class="modal-content">

--- a/index.html
+++ b/index.html
@@ -645,9 +645,9 @@ page_id: home
             <div class="lgx-subscriber-area">
               <h4 class="title">Don’t miss any updates of our new templates and extensions and all the astonishing offers we bring for you.</h4>
               <div class="lgx-subscriber">
-                <form name="Blog Signup" method="POST" class="subscribe-form">
+                <form name="Blog Signup" method="POST" data-netlify="true" action="/" class="subscribe-form">
                   <div class="form-group">
-                    <input name="email" type="email" id="subscribe" placeholder="Ex: yourname@gmail.com" class="form-control lgx-input-form form-control" />
+                    <input name="email" type="email" id="subscribe" placeholder="Ex: yourname@gmail.com" class="form-control lgx-input-form" />
                   </div>
                   <div class="form-group">
                     <button type="submit" data-toggle="modal" data-target="#thank-you-modal" name="lgx-submit" id="lgx-submit" class="lgx-submit the-submit-btn rippler rippler-default"><i class="fa fa-long-arrow-right" aria-hidden="true"></i></button>

--- a/index.html
+++ b/index.html
@@ -645,12 +645,12 @@ page_id: home
             <div class="lgx-subscriber-area">
               <h4 class="title">Don’t miss any updates of our new templates and extensions and all the astonishing offers we bring for you.</h4>
               <div class="lgx-subscriber">
-                <form name="Blog Signup" method="POST" data-netlify="true" action="/" class="subscribe-form">
+                <form name="Blog Signup" method="POST" data-netlify="true" action="/thanks" class="subscribe-form">
                   <div class="form-group">
                     <input name="email" type="email" id="subscribe" placeholder="Ex: yourname@gmail.com" class="form-control lgx-input-form" />
                   </div>
                   <div class="form-group">
-                    <button type="button" data-toggle="modal" data-target="#thank-you-modal" name="lgx-submit" id="lgx-submit" class="lgx-submit the-submit-btn rippler rippler-default"><i class="fa fa-long-arrow-right" aria-hidden="true"></i></button>
+                    <button type="submit" data-toggle="modal" data-target="#thank-you-modal" onclick="passName();" name="lgx-submit" id="lgx-submit" class="lgx-submit the-submit-btn rippler rippler-default"><i class="fa fa-long-arrow-right" aria-hidden="true"></i></button>
                     <div id="thank-you-modal" class="modal fade lgx-modal">
                       <div class="modal-dialog">
                         <div class="modal-content">

--- a/index.html
+++ b/index.html
@@ -650,7 +650,7 @@ page_id: home
                     <input name="email" type="email" id="subscribe" placeholder="Ex: yourname@gmail.com" class="form-control lgx-input-form" />
                   </div>
                   <div class="form-group">
-                    <button type="submit" data-toggle="modal" data-target="#thank-you-modal" name="lgx-submit" id="lgx-submit" class="lgx-submit the-submit-btn rippler rippler-default"><i class="fa fa-long-arrow-right" aria-hidden="true"></i></button>
+                    <button type="button" data-toggle="modal" data-target="#thank-you-modal" name="lgx-submit" id="lgx-submit" class="lgx-submit the-submit-btn rippler rippler-default"><i class="fa fa-long-arrow-right" aria-hidden="true"></i></button>
                     <div id="thank-you-modal" class="modal fade lgx-modal">
                       <div class="modal-dialog">
                         <div class="modal-content">

--- a/index.html
+++ b/index.html
@@ -645,12 +645,24 @@ page_id: home
             <div class="lgx-subscriber-area">
               <h4 class="title">Don’t miss any updates of our new templates and extensions and all the astonishing offers we bring for you.</h4>
               <div class="lgx-subscriber">
-                <form name="Blog Signup" method="POST" data-netlify="true" class="subscribe-form" >
+                <form name="Blog Signup" method="POST" class="subscribe-form">
                   <div class="form-group">
                     <input name="email" type="email" id="subscribe" placeholder="Ex: yourname@gmail.com" class="form-control lgx-input-form form-control" />
                   </div>
                   <div class="form-group">
-                    <button type="submit" name="lgx-submit" id="lgx-submit" class="lgx-submit the-submit-btn rippler rippler-default"><i class="fa fa-long-arrow-right" aria-hidden="true"></i></button>
+                    <button type="button" data-toggle="modal" data-target="#thank-you-modal" name="lgx-submit" id="lgx-submit" class="lgx-submit the-submit-btn rippler rippler-default"><i class="fa fa-long-arrow-right" aria-hidden="true"></i></button>
+                    <div id="thank-you-modal" class="modal fade lgx-modal">
+                      <div class="modal-dialog">
+                        <div class="modal-content">
+                          <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+                          </div>
+                          <div class="modal-body">
+                            Thank you for subscribing!
+                          </div>
+                        </div>
+                      </div> <!-- //.Modal-->
+                    </div>
                   </div>
                 </form>
               </div> <!--//.SUBSCRIBE-->

--- a/index.html
+++ b/index.html
@@ -645,7 +645,7 @@ page_id: home
             <div class="lgx-subscriber-area">
               <h4 class="title">Don’t miss any updates of our new templates and extensions and all the astonishing offers we bring for you.</h4>
               <div class="lgx-subscriber">
-                <form name="Blog Signup" method="POST" data-netlify="true" class="subscribe-form">
+                <form name="Blog Signup" method="POST" class="subscribe-form">
                   <div class="form-group">
                     <input name="email" type="email" id="subscribe" placeholder="Ex: yourname@gmail.com" class="form-control lgx-input-form form-control" />
                   </div>

--- a/thanks.html
+++ b/thanks.html
@@ -1,11 +1,10 @@
 ---
-title: Thanks
-alt_title: Thank you for submitting the form
 layout: sub
 permalink: "/thanks"
 redirect_from:
 - "/thank-you/"
 ---
+
 
 
 <!-- FOUR PANELS WITH INITIATIVES -->


### PR DESCRIPTION
Replacement of link to netlify with a popup modal box on blog subscription submission. 
Two important notes:
- Commit 3474 (previous commit) has popup and submits but page is quickly reloaded
- Commit f1ca25fe (current) does not submit any data but displays popup in most normal manner

Because of netlify form submission code, each form submission must either go to their generic link or link to another page/reload page. If we do not like how the previous commit looks, we will need to create a new form handler for this feature, which can be easily added to the current commit.

Let me know what you think!
