### PR TITLE
add new script and css to fix instagram footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -49,11 +49,10 @@
                     <div class="col-xs-12 col-sm-6 col-md-4 visible-md-block visible-lg-block">
                         <div class="lgx-footer-single">
                             <h2 class="title">Instagram Feed</h2>
-                            <div id="instafeed">
-                            </div>
+                                <ul id="instafeed">
+                                </ul>
                         </div>
-                    </div>
-                </div> <!-- /CONTAINER -->
+                    </div> <!-- /CONTAINER -->
                 <div class="lgx-footer-bottom">
                     <div class="lgx-copyright">
                         <ul class="list-inline">

--- a/_includes/js-imports.html
+++ b/_includes/js-imports.html
@@ -69,5 +69,6 @@
 <script src="/assets/js/lazy-load-images.js" async></script>
 
 
-<!-- Login for Instagram API-->
+<!-- Instagram API-->
+<script src="/assets/js/new-instagram.js"></script>
 <script> window.fbAsyncInit=function(){FB.init({appId:'787477404979745',cookie:true,xfbml:true,version:'v3.3'});FB.AppEvents.logPageView();};(function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(d.getElementById(id)){return;} js=d.createElement(s);js.id=id;js.src="https://connect.facebook.net/en_US/sdk.js";fjs.parentNode.insertBefore(js,fjs);}(document,'script','facebook-jssdk'));</script>

--- a/assets/js/new-instagram.js
+++ b/assets/js/new-instagram.js
@@ -1,0 +1,13 @@
+var token = '899354552.dec2564.b42f33dd198f4c3197892e2973f4bd80',
+    num_photos = 9, // maximum 20
+    container = document.getElementById('instafeed'), // it is our <ul id="rudr_instafeed">
+    scrElement = document.createElement('script');
+
+window.mishaProcessResult = function (data) {
+    for (x in data.data) {
+        container.innerHTML += '<li class="igPost"><img src="' + data.data[x].images.low_resolution.url + '" ></li>';
+    }
+}
+
+scrElement.setAttribute('src', 'https://api.instagram.com/v1/users/self/media/recent?access_token=' + token + '&count=' + num_photos + '&callback=mishaProcessResult');
+document.body.appendChild(scrElement);

--- a/assets/js/new-instagram.js
+++ b/assets/js/new-instagram.js
@@ -1,5 +1,5 @@
 var token = '899354552.dec2564.b42f33dd198f4c3197892e2973f4bd80',
-    num_photos = 9, // maximum 20
+    num_photos = 8, // maximum 20
     container = document.getElementById('instafeed'), // it is our <ul id="rudr_instafeed">
     scrElement = document.createElement('script');
 
@@ -7,6 +7,7 @@ window.mishaProcessResult = function (data) {
     for (x in data.data) {
         container.innerHTML += '<li class="igPost"><img src="' + data.data[x].images.low_resolution.url + '" ></li>';
     }
+    container.innerHTML += '<li> <a href="https://www.instagram.com/awesomeinclex/"><i class="fa fa-angle-double-right fa-4x" id="cont-icon"></i></a></li>';
 }
 
 scrElement.setAttribute('src', 'https://api.instagram.com/v1/users/self/media/recent?access_token=' + token + '&count=' + num_photos + '&callback=mishaProcessResult');

--- a/assets/sass/layout/_footer.scss
+++ b/assets/sass/layout/_footer.scss
@@ -31,7 +31,7 @@
 
 #instafeed {
     list-style: none;
-    column-count: 3;
+    //column-count: 3;
     float: left;
     padding: 0;
 
@@ -40,6 +40,8 @@
         height: 100px;
         align-content: center;
         display: inline-flex; //deals with different images sizes
+        margin-right: 10px;
+
         img {
             max-height: 100px;
             width: 100px;
@@ -59,13 +61,24 @@
                 height: auto;
                 z-index: 3;
                 opacity: 1;
-                -ms-transform: scale(3);
-                -moz-transform: scale(3);
-                -webkit-transform: scale(3);
-                -o-transform: scale(3);
-                transform: scale(3);
+                -ms-transform: scale(2);
+                -moz-transform: scale(2);
+                -webkit-transform: scale(2);
+                -o-transform: scale(2);
+                transform: scale(2);
                 max-height: none;
             }
+        }
+
+        a {
+                position: relative;
+                top: -35px;
+        }
+    }
+
+    li.igPost:nth-child(8) {
+        @include screen-lg {
+            display: none;
         }
     }
 

--- a/assets/sass/layout/_footer.scss
+++ b/assets/sass/layout/_footer.scss
@@ -30,37 +30,41 @@
 }
 
 #instafeed {
-  //max-width: 350px;
-  a {
-    //width: 100%;
-    //position: relative;
-    overflow: hidden;
-    width: 33.33%;
+    list-style: none;
+    column-count: 3;
     float: left;
-    img {
-      padding-right: 4px;
-      padding-bottom: 4px;
-      border-radius: 6px;
-      opacity: .8;
-      height: 90px;
-      @include transition-duration($duration: 0.3s);
-      -ms-transform: scale(2);
-      -moz-transform: scale(2);
-      -webkit-transform: scale(2);
-      -o-transform: scale(2);
-      transform: scale(2);
+    padding: 0;
+
+    li {
+        width: 100px;
+        height: 100px;
+        align-content: center;
+        display: inline-flex; //deals with different images sizes
+        img {
+            max-height: 100px;
+            width: 100px;
+            position: relative;
+            z-index: 1;
+            padding-right: 4px;
+            padding-bottom: 4px;
+            border-radius: 6px;
+            opacity: .9;
+            will-change: transform; //NOTE: this line is necessary so that the transform overflow is not auto-clipped, always clips off otherwise
+            @include transition-duration($duration: 0.3s);
+        }
+
+        &:hover {
+            img {
+                z-index: 3;
+                opacity: 1;
+                -ms-transform: scale(3);
+                -moz-transform: scale(3);
+                -webkit-transform: scale(3);
+                -o-transform: scale(3);
+                transform: scale(3);
+            }
+        }
     }
-    &:hover {
-      img {
-        opacity: 1;
-        -ms-transform: scale(3);
-        -moz-transform: scale(3);
-        -webkit-transform: scale(3);
-        -o-transform: scale(3);
-        transform: scale(3);
-      }
-    }
-  }
 }
 
 .lgx-footer {

--- a/assets/sass/layout/_footer.scss
+++ b/assets/sass/layout/_footer.scss
@@ -43,6 +43,7 @@
         img {
             max-height: 100px;
             width: 100px;
+            height: auto;
             position: relative;
             z-index: 1;
             padding-right: 4px;
@@ -55,6 +56,7 @@
 
         &:hover {
             img {
+                height: auto;
                 z-index: 3;
                 opacity: 1;
                 -ms-transform: scale(3);
@@ -62,8 +64,16 @@
                 -webkit-transform: scale(3);
                 -o-transform: scale(3);
                 transform: scale(3);
+                max-height: none;
             }
         }
+    }
+
+    #cont-icon {
+        width: 100px;
+        height: 100px;
+        padding-top: 15px;
+        padding-left: 10px;
     }
 }
 


### PR DESCRIPTION
Redo of old instagram feed in footer. Now uses a workaround script instead of Instagram's actual API, which is far too restrictive. Currently 9 elements are pulled (max of 20) and formatted into a grid using some CSS magic. All images are adjusted to fit into 100x100 squares while still fitting in the grid correctly, along with allowing zoom on mouse hover. Let me know if you like the design.