### PR TITLE
Changes to past event display for 5across

### DIFF
--- a/_recurring_events/5across.html
+++ b/_recurring_events/5across.html
@@ -13,9 +13,9 @@ redirect_from:
   - 'events/5-acrossnew'
 subtitle: A Pitch Competition for Kentucky Entrepreneurs
 logo_path: '/images/5Across/5Across_Logo.png' 
-next_event_date: May 26, 2021
-next_event_location: "Location: Lexington Legends Whitaker Bank Ballpark"
-next_event_title: 5 Across - May Edition
+next_event_date: February 24, 2021
+next_event_location: "Location: TBA"
+next_event_title: 5 Across - February Edition
 ---
 
 <!--
@@ -44,7 +44,7 @@ next_event_title: 5 Across - May Edition
               <h2 class="title lgx-zoomIn-one heading-title">A Pitch Competition for Kentucky Entrepreneurs</h2>
             </div>
             <div class="buttons">
-              <button type="button" class="lgx-btn lgx-btn-grey" id="applyButton" onclick="location.href='https:\/\/forms.zohopublic.com/virtualoffice9155/form/5AcrossApplication1/formperma/i3hM2QiFcJG1DM_nCW8jQvMplp5UUFgRbKc5Ev8kuiA'">Apply to Pitch</button>
+              <button type="button" class="lgx-btn lgx-btn-grey" id="applyButton" onclick="location.href='http:\/\/www.docs.google.com/spreadsheet/embeddedform?formkey=dF9KeS1iZ1ZETjFKazlBN1U2emlId0E6MA'">Apply to Pitch</button>
               <button type="button" class="lgx-btn lgx-btn-grey" role="button" aria-disabled="true" id="registerButton" onclick="location.href='http:\/\/www.eventbrite.com/e/{{ next_event.first.eventbrite_id }}'">Register to Attend</button>
             </div>
           </div>
@@ -80,7 +80,7 @@ next_event_title: 5 Across - May Edition
   <div class="row">
     <div class="col-md-6 col-md-offset-3">
       <div class="buttons">
-        <button type="button" class="lgx-btn lgx-btn-grey" id="applyButton" onclick="location.href='https:\/\/forms.zohopublic.com/virtualoffice9155/form/5AcrossApplication1/formperma/i3hM2QiFcJG1DM_nCW8jQvMplp5UUFgRbKc5Ev8kuiA'">Apply to Pitch</button>
+        <button type="button" class="lgx-btn lgx-btn-grey" id="applyButton" onclick="location.href='http:\/\/www.docs.google.com/spreadsheet/embeddedform?formkey=dF9KeS1iZ1ZETjFKazlBN1U2emlId0E6MA'">Apply to Pitch</button>
         <button type="button" class="lgx-btn lgx-btn-grey" role="button" aria-disabled="true" id="registerButton" onclick="location.href='http:\/\/www.eventbrite.com/e/{{ next_event.first.eventbrite_id }}'">Register to Attend</button>
       </div>
     </div> <!-- col -->
@@ -156,14 +156,13 @@ next_event_title: 5 Across - May Edition
   <div class="container">
     <div class="row">
       <div class="recent-winner">
-        <p>Congratulations to the 2020 5Across Finals Winner</p>
+        <p>More from our most recent winner</p>
         <div class="box">
           <div class="box-inner">
             <img src="/assets/img/5-across/recent-winner-level-up.jpg" style="object-fit: cover;" />
             <div class="details">
               <h1>Level Up</h1>
               <h2>Kentucky</h2>
-             <h4> <a href="https://www.podchaser.com/podcasts/awesome-inc-805263/episodes/5-across-level-up-your-learnin-82532443" target="_blank">Hear from Natalia Bishop on the Awesome Inc podcast</a> </h4> 
               <div class="youtube">
                 <img src="/images/5Across/5Across_Logo.png" />
               </div>
@@ -173,24 +172,9 @@ next_event_title: 5 Across - May Edition
       </div>
       <div class="revisit">
         <p id="revisit-previous-winner">Or Revisit a Previous Winner</p>
-        <!-- Script to change winners displayed based on value chosen for year-->
-        <script>
-          function yearCheck(years) {
-            if (years.value == "2020") {
-              document.getElementById("2020months").style.display = "flex";
-              document.getElementById("2019months").style.display = "none";
-            }
-            else if (years.value == "2019") {
-              document.getElementById("2020months").style.display = "none";
-              document.getElementById("2019months").style.display = "flex";
-            }
-          }
-        </script>
-        
-          <select name="years" id="years" onchange="yearCheck(years)">
+        <select name="years" id="years" onchange="selectChange();">
           <option value="2020">2020</option>
           <option value="2019">2019</option>
-          <!-- Commenting out until it serves a purpose
           <option value="2018">2018</option>
           <option value="2017">2017</option>
           <option value="2016">2016</option>
@@ -200,100 +184,25 @@ next_event_title: 5 Across - May Edition
           <option value="2012">2012</option>
           <option value="2011">2011</option>
           <option value="2010">2010</option>
-          -->
         </select>
-      
-      <div class="months" onload="loaded();">
-        <div class="months" id = "2020months" style="display: flex;">
-          <div class="februaryX month" id="februaryX">
+        <div class="months" onload="loaded();">
+          <div class="event1 month" id="event1">
             <div class="box-header">
-              <p>February 2020</p>
+              <p></p>
             </div>
             <div class="box">
               <div class="content">
-                <p><a href="https://cgn.us/home/" target="_blank">CGN.US</a></p>
-                <p>Founders:</p>
-                <p class="founder1">Zach Heck</p>
-              </div>
-            </div>
-            </div>
-            <div class="julyX month" id="julyX">
-              <div class="box-header">
-                <p>July 2020</p>
-              </div>
-              <div class="box">
-                <div class="content">
-                  <p><a href="https://hexalayer.com/" target="_blank">HeXalayer</a></p>
-                  <p>Founders:</p>
-                  <p class="founder1">Harut Vardanyan</p>
-                  <p class="founder2">Tereza Paronyan</p>
-                </div>
-              </div>
-              </div>
-              <div class="augustX month" id="augustX">
-                <div class="box-header">
-                  <p>August 2020</p>
-                </div>
-                <div class="box">
-                  <div class="content">
-                    <p><a href="https://levelupwithus.com/" target="_blank">Level Up, LLC</a></p>
-                    <p>Founders:</p>
-                    <p class="founder1">Natalia Bishop</p>
-                    <p class="founder2">Hannah Estes</p>
-                    <p class="founder3">Erica Sartini-Combs</p>
-                    <p class="founder4">Maria Serrano</p>
-                  </div>
-                </div>
-                </div>
-                <div class="octoberX month" id="octoberX">
-                  <div class="box-header">
-                    <p>October 2020</p>
-                  </div>
-                  <div class="box">
-                    <div class="content">
-                      <p><a href="https://getborderless.com/" target="_blank">Borderless</a></p>
-                      <p>Founders:</p>
-                      <p class="founder1">Raffi Kayat + 8 others</p>
-                    </div>
-                  </div>
-                  </div>
-                  <div class="decemberX month" id="decemberX">
-                    <div class="box-header">
-                      <p>Finals 2020</p>
-                    </div>
-                    <div class="box">
-                      <div class="content">
-                        <p><a href="https://levelupwithus.com/" target="_blank">Level Up, LLC</a></p>
-                        <p>Founders:</p>
-                        <p class="founder1">Natalia Bishop</p>
-                        <p class="founder2">Hannah Estes</p>
-                        <p class="founder3">Erica Sartini-Combs</p>
-                        <p class="founder4">Maria Serrano</p>
-                      </div>
-                    </div>
-                    </div>
-                  </div>
-                 
-      <div class="months" id = "2019months" style="display: none;">     
-          <div class="februaryX month" id="februaryX">
-            <div class="box-header">
-              <p>February 2019</p>
-            </div>
-            <div class="box">
-              <div class="content">
-                <p>Kare Mobile</p>
-                <p>Founders:</p>
+                <p></p>
+                <p></p>
                 <p class="founder1">Kwane Watson</p>
                 <p class="founder2"></p>
               </div>
             </div>
-            <!--
             <div class="box-footer">
               <button class="lgx-btn video-url">Watch Video</button>
             </div>
-          -->
           </div>
-          <div class="aprilX month" id="aprilX">
+          <div class="event2 month" id="event2">
             <div class="box-header">
               <p>April 2019</p>
             </div>
@@ -305,13 +214,11 @@ next_event_title: 5 Across - May Edition
                 <p class="founder2"></p>
               </div>
             </div>
-            <!--
             <div class="box-footer">
-              <button class="lgx-btn video-url" onclick="location.href='#'">Watch Video</button>
+              <button class="lgx-btn video-url">Watch Video</button>
             </div>
-          -->
           </div>
-          <div class="juneX month" id="juneX">
+          <div class="event3 month" id="event3">
             <div class="box-header">
               <p>June 2019</p>
             </div>
@@ -323,13 +230,11 @@ next_event_title: 5 Across - May Edition
                 <p class="founder2">Rebekah Gossom</p>
               </div>
             </div>
-            <!--
             <div class="box-footer">
               <button class="lgx-btn video-url">Watch Video</button>
             </div>
-          -->
           </div>
-          <div class="augustX month" id="augustX">
+          <div class="event4 month" id="event4">
             <div class="box-header">
               <p>August 2019</p>
             </div>
@@ -337,17 +242,15 @@ next_event_title: 5 Across - May Edition
               <div class="content">
                 <p>Life Ready Schools</p>
                 <p>Founders:</p>
-                <p class="founder1">Joshua Wilson</p>
-                <p class="founder2">Ryan McQuerry</p>
+                <p class="founder1">Founder Name</p>
+                <p class="founder2">Founder Name</p>
               </div>
             </div>
-            <!--
             <div class="box-footer">
               <button class="lgx-btn video-url">Watch Video</button>
             </div>
-          -->
           </div>
-          <div class="octoberX month" id="octoberX">
+          <div class="event5 month" id="event5">
             <div class="box-header">
               <p>October 2019</p>
             </div>
@@ -359,13 +262,11 @@ next_event_title: 5 Across - May Edition
                 <p class="founder2"></p>
               </div>
             </div>
-            <!--
             <div class="box-footer">
               <button class="lgx-btn video-url">Watch Video</button>
             </div>
           </div>
-        -->
-          <div class="finalsX month" id="finalsX">
+          <div class="event6 month" id="event6">
             <div class="box-header">
               <p>Finals 2019</p>
             </div>
@@ -377,14 +278,12 @@ next_event_title: 5 Across - May Edition
                 <p class="founder2"></p>
               </div>
             </div>
-            <!--
             <div class="box-footer">
               <button class="lgx-btn video-url">Watch Video</button>
             </div>
-          -->
           </div>
         </div>
-      </div> 
+      </div> -->
     </div>
   </div>
 </section>

--- a/assets/js/5across.js
+++ b/assets/js/5across.js
@@ -1,7 +1,7 @@
 let obj = {};
 
 document.getElementsByTagName("body")[0].onload = () => {
-    $.get("/assets/js/5across_past.json", (data, status) => {
+    $.get("/assets/js/5across.json", (data, status) => {
         console.log("Data:");
         console.log(data);
         const jsonObj = data;
@@ -12,31 +12,35 @@ document.getElementsByTagName("body")[0].onload = () => {
 
 function selectChange() {
     const value = document.getElementById("years").value;
-    const index = 2019 - Number(value);
-    const months = {
-        "February": document.getElementById("februaryX"),
-        "April": document.getElementById("aprilX"),
-        "June": document.getElementById("juneX"),
-        "August": document.getElementById("augustX"),
-        "October": document.getElementById("octoberX"),
-        "Finals": document.getElementById("finalsX")
+    const index = 2020 - Number(value);
+    const events = {
+        "Event1": document.getElementById("event1"),
+        "Event2": document.getElementById("event2"),
+        "Event3": document.getElementById("event3"),
+        "Event4": document.getElementById("event4"),
+        "Event5": document.getElementById("event5"),
+        "Event6": document.getElementById("event6")
     };
-    Object.values(months).forEach((val, ind) => {
-        val.children[0].children[0].innerHTML = `${Object.keys(months)[ind]} ${value}`;
+
+    Object.values(events).forEach((val, ind) => {
+        val.children[0].children[0].innerHTML = `${obj.years[value][Object.keys(events)[ind]].month} ${value}`;
         const info = val.children[1].children[0];
-        if (obj.years[value][Object.keys(months)[ind]].winner != undefined) {
-            info.children[0].innerHTML = obj.years[value][Object.keys(months)[ind]].winner;
+        if (obj.years[value][Object.keys(events)[ind]].winner != "") {
+            info.children[0].innerHTML = obj.years[value][Object.keys(events)[ind]].winner;
         }
         else {
-            info.children[0].innerHTML = "No event this month!";
+            info.children[0].innerHTML = "No Event";
+            info.children[1].innerHTML = "";
+            console.log(val.children[2].innerHTML);
         }
-        info.children[2].innerHTML = obj.years[value][Object.keys(months)[ind]].founder || "";
-        info.children[3].innerHTML = obj.years[value][Object.keys(months)[ind]].founder2 || "";
+
+        info.children[2].innerHTML = obj.years[value][Object.keys(events)[ind]].founder || "";
+        info.children[3].innerHTML = obj.years[value][Object.keys(events)[ind]].founder2 || "";
         const link_buttons = document.getElementsByClassName("video-url");
-        console.log(obj.years[value][Object.keys(months)[ind]]);
-        if (obj.years[value][Object.keys(months)[ind]]["url"] != "#") {
+        console.log(obj.years[value][Object.keys(events)[ind]]);
+        if (obj.years[value][Object.keys(events)[ind]]["url"] != "#") {
             link_buttons[ind].onclick = () => {
-                location.href = obj.years[value][Object.keys(months)[ind]]["url"] || "#";
+                location.href = obj.years[value][Object.keys(events)[ind]]["url"] || "#";
             }
         }
         else {
@@ -44,5 +48,5 @@ function selectChange() {
                 alert("Coming soon!");
             }
         }
-    });
-}
+        })
+    }

--- a/assets/js/5across.json
+++ b/assets/js/5across.json
@@ -2,31 +2,37 @@
   "years": {
     "2010": {
       "Event1": {
+        "month": "February",
         "winner": "Restaurant Outlets",
         "url": "https://www.youtube.com/watch?v=Oz0127bPU9Q&amp;width=640&amp;height=480",
         "founder": "David Slone"
       },
       "Event2": {
+        "month": "April",
         "winner": "Wedding Captions",
         "url": "https://www.youtube.com/watch?v=KWLqWYoM3DI&amp;width=640&amp;height=480",
         "founder": "Nathan McConathy"
       },
       "Event3": {
+        "month": "June",
         "winner": "Bhoppers",
         "url": "https://www.youtube.com/watch?v=lVTgXimKqHY&amp;width=640&amp;height=480",
         "founder": "Gip Gibson"
       },
       "Event4": {
+        "month": "August",
         "winner": "Parlay",
         "url": "https://www.youtube.com/watch?v=4M49PsJhbbE&amp;width=640&amp;height=480",
         "founder": "Andre Henderson"
       },
       "Event5": {
+        "month": "October",
         "winner": "Webatures",
         "url": "https://www.youtube.com/watch?v=FPMDh-VPPOA&amp;width=640&amp;height=480",
         "founder": "Tuan Ho"
       },
-      "Finals": {
+      "Event6": {
+        "month": "December (Finals)",
         "winner": "Wedding Captions",
         "url": "https://www.youtube.com/watch?v=KVLSr5OHDKQ&amp;width=640&amp;height=480",
         "founder": "David Slone"
@@ -34,117 +40,139 @@
     },
     "2011": {
       "Event1": {
+        "month": "February",
         "winner": "Frogdice",
         "url": "https://www.youtube.com/watch?v=x3js4YHc0vk&width=640&height=480",
         "founder": "Michael Hartman"
       },
       "Event2": {
+        "month": "April",
         "winner": "iJonze",
         "url": "https://www.youtube.com/watch?v=nk3k-dQfgrI&width=640&height=480",
         "founder": "Shawn Campbell"
       },
       "Event3": {
+        "month": "June",
         "winner": "ACLerator",
         "url": "https://www.youtube.com/watch?v=SFrARcNrKB0&width=640&height=480",
         "founder": "Eric Hartman"
       },
       "Event4": {
-        "winner": "???",
-        "url": "#"
-      },
-      "Event5": {
+        "month": "October",
         "winner": "Crowded",
         "url": "https://www.youtube.com/watch?v=q_q8LU0Vr9M&width=640&height=480",
         "founder": "Evan Leach",
         "founder2": "Scott Wagner"
       },
-      "Finals": {
-        "winner": "???",
-        "url": "#",
-        "founder": "???"
+      "Event5": {
+        "month": "",
+        "winner": ""
+      },
+      "Event6": {
+        "month": "",
+        "winner": ""
       }
     },
     "2012": {
       "Event1": {
-        "winner": "???"
-      },
-      "Event2": {
+        "month": "April",
         "winner": "Last Call Ventures",
         "url":"https://www.youtube.com/watch?v=J-GjAuw5zAs&width=640&height=480",
         "founder": "Cameron Lippert"
       },
-      "Event3": {
+      "Event2": {
+        "month": "June",
         "winner": "Rate My Rental",
         "url":"https://www.youtube.com/watch?v=3BU0yssYtho&width=640&height=480",
         "founder": "Nick Jordan",
         "founder2": "Kyle Vaughn"
       },
-      "Event4": {
+      "Event3": {
+        "month": "August",
         "winner": "Alliance Virtual Office",
         "url":"https://www.youtube.com/watch?v=kCDxUI2YLak&width=640&height=480",
         "founder": "Mike Sullivan"
       },
-      "Event5": {
+      "Event4": {
+        "month": "October",
         "winner": "Earthineer",
         "url":"https://www.youtube.com/watch?v=pgFC2oNHV40&width=640&height=480",
         "founder": "Dan Adams",
         "founder2": "Jeff Crosby"
       },
-      "Finals": {
+      "Event5": {
+        "month": "",
+        "winner": ""
+      },
+      "Event6": {
+        "month": "",
         "winner": ""
       }
     },
     "2013": {
       "Event1": {
-        "winner": "???"
+        "month": "",
+        "winner": ""
       },
       "Event2": {
-        "winner": "Babylocity OR iReport360"
+        "month": "",
+        "winner": ""
       },
       "Event3": {
-        "winner": "???"
+        "month": "",
+        "winner": ""
       },
       "Event4": {
+        "month": "August",
         "winner": "Custom College Recruiting",
         "url":"https://www.youtube.com/watch?v=LQmScnIysi0&width=640&height=480",
         "founder": "Shane Howard"
       },
       "Event5": {
+        "month": "October",
         "winner": "PowerTech",
         "url":"https://www.youtube.com/watch?v=onLr-diehf8&width=640&height=480",
         "founder": "James Landon"
       },
-      "Finals": {
-        "winner": "???"
+      "Event6": {
+        "month": "",
+        "winner": ""
       }
     },
     "2014": {
       "Event1": {
+        "month": "February",
         "winner": "You Saw Me",
         "url":"https://www.youtube.com/watch?v=lIXmFwGP0iw&width=640&height=480",
-        "founder": "Seth ???"
+        "founder": "Seth McBee"
       },
       "Event2": {
+        "month": "April",
         "winner": "Complete Set",
         "url":"https://www.youtube.com/watch?v=3PHqF-1Wvh4&width=640&height=480",
-        "founder": "???"
+        "founder": "Garry Darna"
       },
       "Event3": {
+        "month": "June",
         "winner": "Blink Scan",
         "url":"https://www.youtube.com/watch?v=AsMtwbpX1WA&width=640&height=480",
-        "founder": "???"
+        "founder": "Don Scags",
+        "founder2": "Steve McFadden"
       },
       "Event4": {
+        "month": "August",
         "winner": "Super Soul",
         "url":"https://www.youtube.com/watch?v=8aSkoxQx2uc&width=640&height=480",
-        "founder": "???"
+        "founder": "John Meister"
       },
       "Event5": {
+        "month": "October",
         "winner": "Vegy Vida",
         "url":"https://www.youtube.com/watch?v=KZLPIRjM_CY&width=640&height=480",
         "founder": "Josh Young"
       },
-      "Finals": {
+      "Event6": {
+        "month": "December (Finals)",
         "winner": "Vegy Vida",
         "url":"https://www.youtube.com/watch?v=NVrNpw85ouA&width=640&height=480",
         "founder": "Josh Young"
@@ -152,61 +180,75 @@
     },
     "2015": {
       "Event1": {
+        "month": "February",
         "winner": "Follow That Food Truck",
         "url":"https://www.youtube.com/watch?v=onhHdgoGrwM&width=640&height=480",
         "founder": "Josh Boldt",
         "founder2": "Erik Rust"
       },
       "Event2": {
+        "month": "April",
         "winner": "Finance U",
         "url":"https://www.youtube.com/watch?v=95m5VWKRajE&width=640&height=480",
         "founder": "Michael Lewis"
       },
       "Event3": {
+        "month": "June",
         "winner": "mRendering",
         "url":"https://www.youtube.com/watch?v=-Wt0LKwTuAc&width=640&height=480",
         "founder": "Paul ???",
         "founder2": "Alexsy ???"
       },
       "Event4": {
-        "winner": ""
-      },
-      "Event5": {
+        "month": "October",
         "winner": "Hillbarrow",
         "url":"https://www.youtube.com/watch?v=fMMxv_nFSsE&width=640&height=480",
         "founder": "Gary Vandelinde",
         "founder2": "Valerie Vandelinde"
       },
-      "Finals": {
+      "Event5": {
+        "month": "December (Finals)",
         "winner": "DonorCentric",
         "founder": "Charles Buddeke"
+      },
+      "Event6": {
+        "month": "",
+        "winner": ""
       }
     },
     "2016": {
       "Event1": {
+        "month": "February",
         "winner": "RaceAssured",
         "url":"https://www.youtube.com/watch?v=g4dNCeQItTw&amp;width=640&amp;height=480",
         "founder": "Stefanie Pagano"
       },
       "Event2": {
-        "winner": "451 Tech Name Change?"
+        "month": "April",
+        "winner": "Kumanari Arts",
+        "url": "https://www.youtube.com/watch?v=dNG_Y0tkmGw&list=PL_YvoQ-KM3YHl7D29MzJClPvRqp_PL7me&index=102",
+        "founder": "Adrienne Thakur"
       },
       "Event3": {
+        "month": "June",
         "winner": "RalphVR",
         "url":"https://www.youtube.com/watch?v=-vPVWPIzWhA&amp;width=640&amp;height=480",
         "founder": "Richard Hoagland"
       },
       "Event4": {
+        "month": "August",
         "winner": "Previsit",
         "url":"https://www.youtube.com/watch?v=pZSEc-kY72Y&amp;width=640&amp;height=480",
         "founder": "???"
       },
       "Event5": {
+        "month": "October",
         "winner": "Pasiv Duty",
         "url":"https://www.youtube.com/watch?v=133lW7bTHso&amp;width=640&amp;height=480",
         "founder": "Blake Caudill"
       },
-      "Finals": {
+      "Event6": {
+        "month": "December (Finals)",
         "winner": "PASIVDuty",
         "url":"https://www.youtube.com/watch?v=133lW7bTHso&amp;width=640&amp;height=480",
         "founder": "Blake Caudill"
@@ -214,31 +256,38 @@
     },
     "2017": {
       "Event1": {
+        "month": "February",
         "winner": "Welcome Home",
         "url":"https://youtu.be/u0NTlLWTc5g",
         "founder": "Kai Zhang"
       },
       "Event2": {
+        "month": "April",
         "winner": "Smart Student Storage",
         "url":"https://www.youtube.com/watch?v=UyeicQMkycQ",
         "founder": "Alexandria George"
       },
       "Event3": {
+        "month": "June",
         "winner": "Bill Busters",
         "url":"https://youtu.be/94Np-6NPH00",
-        "founder": "???"
+        "founder": "Michael Kaser",
+        "founder2": "Tyler Menke"
       },
       "Event4": {
+        "month": "August",
         "winner": "Enepret",
         "url":"https://youtu.be/REqnOF6pntw",
         "founder": "Chase Kempinski"
       },
       "Event5": {
+        "month": "October",
         "winner": "Sum180",
         "url":"https://youtu.be/C6Ru4dog678",
         "founder": "Carla Dearing"
       },
-      "Finals": {
+      "Event6": {
+        "month": "December (Finals)",
         "winner": "WelcomeHome",
         "url":"https://youtu.be/8ioNIbmy17M",
         "founder": "Kai Zhang"
@@ -246,33 +295,39 @@
     },
     "2018": {
       "Event1": {
+        "month": "February",
         "winner": "Pascal Tags",
         "url":"https://youtu.be/flLlyRyGHXQ",
         "founder": "Brandon Young",
         "founder2": "Hailey Pfeiffer"
       },
       "Event2": {
+        "month": "April",
         "winner": "Chez",
         "url":"https://www.youtube.com/watch?v=gjK0i3D1D3k",
         "founder": "Kyle Wadsworth",
         "founder2": "Russ Davenport"
       },
       "Event3": {
+        "month": "June",
         "winner": "Wild Dog Physics",
         "url":"https://www.youtube.com/watch?v=R18Cd2wHrUE",
         "founder": "Jenelle Molloy"
       },
       "Event4": {
+        "month": "August",
         "winner": "Moolathon",
         "url":"https://youtu.be/9mEY0XMwyhE",
         "founder": "Mac Wilkinson"
       },
       "Event5": {
+        "month": "October",
         "winner": "EZ Gig",
         "url":"https://youtu.be/ORDCqIC7gzM",
-        "founder": "???"
+        "founder": "Lyle Hanna"
       },
-      "Finals": {
+      "Event6": {
+        "month": "December (Finals)",
         "winner": "PascalTags",
         "founder": "Brandon Young",
         "founder2": "Hailey Pfeiffer"
@@ -280,33 +335,39 @@
     },
     "2019": {
       "Event1": {
+        "month": "February",
         "winner": "Kare Mobile",
         "url":"https://youtu.be/6JjKq-cOGhU",
         "founder": "Kwane Watson",
         "founder2": "Brittany Becker"
       },
       "Event2": {
+        "month": "April",
         "winner": "EZ Chow",
         "url":"https://youtu.be/8HhKjvmE7F0",
         "founder": "Mo Sloan"
       },
       "Event3": {
+        "month": "June",
         "winner": "Innovative Therapeutix",
         "url": "#",
         "founder": "Michael Detmer"
       },
       "Event4": {
+        "month": "August",
         "winner": "Life Ready Schools",
         "url": "#",
         "founder": "Joshua Wilson",
         "founder2": "Ryan McQuerry"
       },
       "Event5": {
+        "month": "October",
         "winner": "Stellar Plants",
         "url": "https://youtu.be/dmG26LtYcFs",
         "founder": "Joseph Cox"
       },
-      "Finals": {
+      "Event6": {
+        "month": "December (Finals)",
         "winner": "EZ Chow",
         "url":"https://youtu.be/8HhKjvmE7F0",
         "founder": "Mo Sloan"
@@ -314,17 +375,20 @@
     },
     "2020": {
       "Event1": {
+        "month": "February",
         "winner": "CGN.US",
         "url":"https://cgn.us/",
         "founder": "Zach Heck"
       },
       "Event2": {
+        "month": "July",
         "winner": "HeXalayer",
         "url":"https://www.hexalayer.com/",
         "founder": "Harut Vardanyan",
         "founder2": "Tereza Paronyan"
       },
       "Event3": {
+        "month": "August",
         "winner": "Level Up, LLC",
         "url": "https://levelupwithus.com/",
         "founder": "Natalia Bishop",
@@ -333,17 +397,23 @@
         "founder4": "Maria Serrano"
       },
       "Event4": {
+        "month": "October",
         "winner": "Bordlerless",
         "url": "https://getborderless.com/",
         "founder": "Raffi Kayat + 8 others"
       },
-      "Finals": {
+      "Event5": {
+        "month": "December (Finals)",
         "winner": "Level Up, LLC",
         "url": "https://levelupwithus.com/",
         "founder": "Natalia Bishop",
         "founder2": "Hannah Estes",
         "founder3": "Erica Sartini-Combs",
         "founder4": "Maria Serrano"
+      },
+      "Event6": {
+        "month": "",
+        "winner": ""
       }
     }
   }


### PR DESCRIPTION
Changed month based system to new event based system for listing past results. They will be written as "Event1, Event2, etc." due to changing of months when we have events. Moved 5across data to /assets/js file so it can be accessed via the web. Fixed the ??? in the JSON data. Current issues include the bottom button still saying "watch video" for 2020 pitches even though it redirects to there websites. Also when less than 6 events happen during a year, the boxes just display "no event", I could not figure out how to modify the css stylesheet to hide elements. Will work on this in the future. 